### PR TITLE
Append to the output file instead of write

### DIFF
--- a/lib/Plack/Middleware/Recorder.pm
+++ b/lib/Plack/Middleware/Recorder.pm
@@ -29,6 +29,7 @@ sub prepare_app {
         $self->{output_fh} = $output;
         $output->autoflush(1);
     } else {
+        my $can_write = IO::File->new($output, 'a') || croak $!;
         $self->{output_filename} = $output;
     }
 }

--- a/lib/Plack/Middleware/Recorder.pm
+++ b/lib/Plack/Middleware/Recorder.pm
@@ -25,7 +25,7 @@ sub prepare_app {
     my $output = $self->{'output'};
     croak "output parameter required" unless defined $output;
 
-    $output = $self->{'output'} = IO::File->new($output, 'w') or croak $!
+    $output = $self->{'output'} = IO::File->new($output, 'a') or croak $!
         unless ref $output;
 
     $output->autoflush(1);

--- a/lib/Plack/Middleware/Recorder.pm
+++ b/lib/Plack/Middleware/Recorder.pm
@@ -167,10 +167,6 @@ retrieves requests.  In the future, I'd like a bunch of features to be added:
 
 =item *
 
-Specifying the output as a filename doesn't work properly with CGI (the middleware clobbers the output file)
-
-=item *
-
 The middleware probably won't function correctly in a concurrent environment like Starman.
 
 =item *

--- a/t/01-record.t
+++ b/t/01-record.t
@@ -6,73 +6,62 @@ use File::Temp;
 use Plack::Builder;
 use Plack::VCR;
 use Plack::Test;
-use Test::More tests => 3;
+use Test::More tests => 16;
 
 my $tempfile = File::Temp->new;
 close $tempfile;
 
-for ( 1 .. 2 ) {
-    my $app = builder {
-        enable 'Recorder', output => $tempfile->filename;
-        sub {
-            [ 200, ['Content-Type' => 'text/plain'], ['OK'] ];
-        };
+my $app = builder {
+    enable 'Recorder', output => $tempfile->filename;
+    sub {
+        [ 200, ['Content-Type' => 'text/plain'], ['OK'] ];
     };
+};
 
-    test_psgi $app, sub {
-        my ( $cb ) = @_;
+test_psgi $app, sub {
+    my ( $cb ) = @_;
 
-        $cb->(GET '/');
-        $cb->(GET '/', 'X-Made-Up-Header' => 17);
-        $cb->(POST '/foo', 'X-Made-Up-Header' => 17, Content => [
-            first_name => 'Rob',
-            last_name  => 'Hoelz',
-            full_name  => 'Rob Hoelz',
-        ]);
-        $cb->(GET '/bar?name=Rob%20Hoelz');
-    };
-}
+    $cb->(GET '/');
+    $cb->(GET '/', 'X-Made-Up-Header' => 17);
+    $cb->(POST '/foo', 'X-Made-Up-Header' => 17, Content => [
+        first_name => 'Rob',
+        last_name  => 'Hoelz',
+        full_name  => 'Rob Hoelz',
+    ]);
+    $cb->(GET '/bar?name=Rob%20Hoelz');
+};
 
 my $vcr = Plack::VCR->new(filename => $tempfile->filename);
+my $interaction;
+my $req;
 
-for ( 1 .. 2 ) {
-    subtest "Plack::VCR iteration $_" => sub {
-        plan tests => 15;
+$interaction = $vcr->next;
+ok $interaction;
+$req = $interaction->request;
+is $req->method, 'GET';
+is $req->uri, '/';
 
-        my $interaction;
-        my $req;
+$interaction = $vcr->next;
+ok $interaction;
+$req = $interaction->request;
+is $req->method, 'GET';
+is $req->uri, '/';
+is $req->header('X-Made-Up-Header'), 17;
 
-        $interaction = $vcr->next;
-        ok $interaction;
-        $req = $interaction->request;
-        is $req->method, 'GET';
-        is $req->uri, '/';
+$interaction = $vcr->next;
+ok $interaction;
+$req = $interaction->request;
+is $req->method, 'POST';
+is $req->uri, '/foo';
+is $req->header('X-Made-Up-Header'), 17;
+is $req->content, 'first_name=Rob&last_name=Hoelz&full_name=Rob+Hoelz';
 
-        $interaction = $vcr->next;
-        ok $interaction;
-        $req = $interaction->request;
-        is $req->method, 'GET';
-        is $req->uri, '/';
-        is $req->header('X-Made-Up-Header'), 17;
+$interaction = $vcr->next;
+ok $interaction;
+$req = $interaction->request;
+is $req->method, 'GET';
+is $req->uri, '/bar?name=Rob%20Hoelz';
 
-        $interaction = $vcr->next;
-        ok $interaction;
-        $req = $interaction->request;
-        is $req->method, 'POST';
-        is $req->uri, '/foo';
-        is $req->header('X-Made-Up-Header'), 17;
-        is $req->content, 'first_name=Rob&last_name=Hoelz&full_name=Rob+Hoelz';
+$interaction = $vcr->next;
+ok ! $interaction;
 
-        $interaction = $vcr->next;
-        ok $interaction;
-        $req = $interaction->request;
-        is $req->method, 'GET';
-        is $req->uri, '/bar?name=Rob%20Hoelz';
-    };
-}
-
-subtest 'VCR iterator is done' => sub {
-    plan tests => 1;
-    my $interaction = $vcr->next;
-    ok ! $interaction;
-};

--- a/t/01-record.t
+++ b/t/01-record.t
@@ -6,62 +6,110 @@ use File::Temp;
 use Plack::Builder;
 use Plack::VCR;
 use Plack::Test;
-use Test::More tests => 16;
+use Test::More tests => 1;
 
-my $tempfile = File::Temp->new;
-close $tempfile;
+my @requests = (
+    { method => 'GET', uri => '/' },
 
-my $app = builder {
-    enable 'Recorder', output => $tempfile->filename;
-    sub {
-        [ 200, ['Content-Type' => 'text/plain'], ['OK'] ];
+    { method => 'GET', uri => '/', headers => [ 'X-Made-Up-Header' => 17 ] },
+
+    { method => 'POST', uri => '/foo', headers => [ 'X-Made-Up-Header' => 17 ],
+      content => [ first_name => 'Rob', last_name  => 'Hoelz', full_name  => 'Rob Hoelz' ] },
+
+    { method => 'GET', uri => '/bar?name=Rob%20Hoelz' },
+);
+
+subtest 'sending requests' => sub {
+    plan tests => 16;
+
+    my $tempfile = File::Temp->new;
+    close $tempfile;
+
+    my $app = builder {
+        enable 'Recorder', output => $tempfile->filename;
+        sub {
+            [ 200, ['Content-Type' => 'text/plain'], ['OK'] ];
+        };
     };
+
+    run_test_psgi_for_requests($app, @requests);
+
+    my $vcr = Plack::VCR->new(filename => $tempfile->filename);
+
+    verify_saved_requests($vcr, @requests);
+
+    my $interaction = $vcr->next;
+    ok ! $interaction, 'iterator exhausted';
 };
 
-test_psgi $app, sub {
-    my ( $cb ) = @_;
+sub run_test_psgi_for_requests {
+    my $app = shift;
 
-    $cb->(GET '/');
-    $cb->(GET '/', 'X-Made-Up-Header' => 17);
-    $cb->(POST '/foo', 'X-Made-Up-Header' => 17, Content => [
-        first_name => 'Rob',
-        last_name  => 'Hoelz',
-        full_name  => 'Rob Hoelz',
-    ]);
-    $cb->(GET '/bar?name=Rob%20Hoelz');
-};
+    my @request_senders = map { construct_request_sender($_) } @_;
 
-my $vcr = Plack::VCR->new(filename => $tempfile->filename);
-my $interaction;
-my $req;
+    test_psgi $app, sub {
+        my ( $cb ) = @_;
+        $cb->($_->()) foreach @request_senders;
+    };
+}
 
-$interaction = $vcr->next;
-ok $interaction;
-$req = $interaction->request;
-is $req->method, 'GET';
-is $req->uri, '/';
+sub verify_saved_requests {
+    my $vcr = shift;
 
-$interaction = $vcr->next;
-ok $interaction;
-$req = $interaction->request;
-is $req->method, 'GET';
-is $req->uri, '/';
-is $req->header('X-Made-Up-Header'), 17;
+    my @request_testers = map { construct_request_tester($_) } @_;
+    foreach my $request_test ( @request_testers ) {
+        my $interaction = $vcr->next;
+        ok $interaction, 'next interaction';
+        $request_test->($interaction->request);
+    }
+}
 
-$interaction = $vcr->next;
-ok $interaction;
-$req = $interaction->request;
-is $req->method, 'POST';
-is $req->uri, '/foo';
-is $req->header('X-Made-Up-Header'), 17;
-is $req->content, 'first_name=Rob&last_name=Hoelz&full_name=Rob+Hoelz';
+sub construct_request_sender {
+    my $req_data = shift;
 
-$interaction = $vcr->next;
-ok $interaction;
-$req = $interaction->request;
-is $req->method, 'GET';
-is $req->uri, '/bar?name=Rob%20Hoelz';
+    my %req_methods = (
+        GET => \&GET,
+        POST => \&POST,
+    );
 
-$interaction = $vcr->next;
-ok ! $interaction;
+    my($method, $uri, $headers, $content) = @$req_data{'method','uri','headers','content'};
+    my @args;
+    if ($headers) {
+        push @args, @$headers;
+    }
+    if ($content) {
+        push @args, ('Content' => $content);
+    }
+
+    my $method_sub = $req_methods{$method};
+    return sub {
+        $method_sub->($uri, @args);
+    }
+}
+
+sub construct_request_tester {
+    my $req_data = shift;
+    my($method, $uri, $headers, $content) = @$req_data{'method','uri','headers','content'};
+
+    return sub {
+        my $req = shift;
+
+        is($req->method, $method, 'method');
+        is($req->uri, $uri, 'uri');
+        if ($headers) {
+            for(my $i = 0; $i < @$headers; $i += 2) {
+                my($header, $value) = @$headers[$i, $i+1];
+                is($req->header($header), $value, "header $header");
+            }
+        }
+        if ($content) {
+            my @expected_content;
+            for (my $i = 0; $i < @$content; $i += 2) {
+                push @expected_content, join('=', map { my $v = $_; $v =~ s/ /+/g; $v } @$content[$i, $i+1]);
+            }
+            my $expected_content = join('&', @expected_content);
+            is($req->content, $expected_content, 'content');
+        }
+    };
+}
 


### PR DESCRIPTION
This way, the output file will persist across invocations of the app, letting it record properly when used as a CGI