### PR TITLE
While writing to the output file, lock using LockFile::Simple

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -27,6 +27,9 @@ Plack::Middleware::Debug = 0
 Pod::Usage               = 0
 Storable                 = 0
 HTTP::Message::PSGI      = 0
+File::Spec               = 0
+Scope::Guard             = 0
+LockFile::Simple         = 0
 [Prereqs / TestRequires]
 HTML::Tree            = 0
 HTTP::Request::Common = 0

--- a/dist.ini
+++ b/dist.ini
@@ -27,9 +27,8 @@ Plack::Middleware::Debug = 0
 Pod::Usage               = 0
 Storable                 = 0
 HTTP::Message::PSGI      = 0
-File::Spec               = 0
 Scope::Guard             = 0
-LockFile::Simple         = 0
+Fcntl                    = 0
 [Prereqs / TestRequires]
 HTML::Tree            = 0
 HTTP::Request::Common = 0

--- a/lib/Plack/Middleware/Recorder.pm
+++ b/lib/Plack/Middleware/Recorder.pm
@@ -135,6 +135,7 @@ sub _has_flock {
     return $has_flock if defined $has_flock;
 
     my $fh = IO::File->new(__FILE__, 'r');
+    local $@;
     eval { flock($fh, LOCK_SH) };
     $has_flock = ! $@;
     return $has_flock;

--- a/t/12-concurrency-lock.t
+++ b/t/12-concurrency-lock.t
@@ -1,0 +1,84 @@
+use strict;
+use warnings;
+
+use HTTP::Request::Common;
+use File::Temp;
+use Plack::Builder;
+use Plack::VCR;
+use Plack::Test;
+use Test::More;
+use IO::File;
+
+my @tests = ( [ 'concurrency off',
+                sub { },
+                sub { ok(! -f $_[0], 'lock file does not exist during write') }
+              ],
+              [ 'multithread concurrency',
+                 sub { $_[0]->{'psgi.multithread'} = 1 },
+                 sub { ok(-f $_[0], 'lock file exists during write') }
+              ],
+              [ 'multitprocess concurrency',
+                sub { $_[0]->{'psgi.multiprocess'} = 1 },
+                sub { ok(-f $_[0], 'lock file exists during write') }
+              ],
+);
+
+plan tests => scalar(@tests);
+
+foreach my $test_desc ( @tests ) {
+    my($desc, $enable_multi, $lockfile_test) = @$test_desc;
+
+    subtest $desc => sub {
+        plan tests => 6;
+
+        my $tempfile = File::Temp->new;
+        close $tempfile;
+
+        my $expected_lock_file = "${tempfile}.lock";
+
+        # Intercept Recorder's write to the output file and test
+        # the locking status
+        my $orig_io_file_write = IO::File->can('write');
+        no warnings 'once';
+        local *IO::File::write = sub {
+            my $fh = shift;
+            $lockfile_test->($expected_lock_file);
+            $fh->$orig_io_file_write(@_);
+        };
+
+        my $app = builder {
+            enable concurrency_setter_middleware($enable_multi);
+            enable 'Recorder', output => $tempfile->filename;
+            sub {
+                [ 200, ['Content-Type' => 'text/plain'], ['OK'] ];
+            };
+        };
+
+        test_psgi $app, sub {
+            my ( $cb ) = @_;
+
+            ok(! -f $expected_lock_file, 'Before request, lock file does not exist');
+            $cb->(GET '/');
+            ok(! -f $expected_lock_file, 'After request, lock file does not exist');
+        };
+
+        my $vcr = Plack::VCR->new(filename => $tempfile->filename);
+        my $interaction = $vcr->next;
+        ok($interaction, 'Got interaction');
+        my $req = $interaction->request;
+        is($req->method, 'GET', 'request method was GET');
+        is($req->uri, '/', 'request URI was /');
+    };
+};
+
+sub concurrency_setter_middleware {
+    my $enable_multi = shift;
+    return sub {
+        my $app = shift;
+        sub {
+            my $env = shift;
+            $enable_multi->($env);
+            $app->($env);
+        };
+    };
+}


### PR DESCRIPTION
If the PSGI environment keys 'psgi.multithread' or 'psgi.multiprocess' are
true, lock the output file before writing to avoid writes stomping over
each other.

It uses LockFile::Simple to implement advisory locking on the output file before each write by dropping a ```*.lock``` file next to the output file.

I'm not sure I'm happy about the test.  It's really too dependent on the implementation of how Recorder writes to the output file and how LockFile::Simple names the lock file.