### PR TITLE
Add MetaJSON plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ copyright_year   = 2015
 
 [@Author::RHOELZ]
 
+[MetaJSON]
 [ExecDir]
 [Test::LocalBrew]
 brews = pristine-5.8


### PR DESCRIPTION
This plugin will automatically generate a `META.json`. `META.json` is the preferred format to
the older `META.yml`.

This PR is part of my January assignment for the [Pull Request Challenge](http://cpan-prc.org/).